### PR TITLE
feat: Phase I concurrent Metal queues

### DIFF
--- a/crates/core/src/compute.rs
+++ b/crates/core/src/compute.rs
@@ -2414,6 +2414,52 @@ pub fn abort_batch() {
     unsafe { ffi::gpu_bridge_abort_batch() }
 }
 
+// ── Concurrent queue pool ──────────────────────────────────────────
+
+/// Get a command queue from the pool by index. Queues are lazily created and reused.
+pub fn get_queue(device: &Device, index: u32) -> *mut std::ffi::c_void {
+    unsafe { ffi::gpu_bridge_get_queue(device.raw_handle(), index) }
+}
+
+// ── Batch context system ──────────────────────────────────────────
+
+/// Create a batch context: a new command buffer on the given queue, keyed by context_id.
+pub fn set_batch_context(context_id: u32, queue: *mut std::ffi::c_void) -> *mut std::ffi::c_void {
+    unsafe { ffi::gpu_bridge_set_batch_context(context_id, queue) }
+}
+
+/// Commit a batch context: commits the command buffer and returns its handle for waiting.
+pub fn commit_batch_context(context_id: u32) -> *mut std::ffi::c_void {
+    unsafe { ffi::gpu_bridge_commit_batch_context(context_id) }
+}
+
+/// Set the active context ID. Subsequent _nb dispatch calls will use this context's CB.
+pub fn set_active_context(context_id: u32) {
+    unsafe { ffi::gpu_bridge_set_active_context(context_id) }
+}
+
+// ── MTLEvent synchronization ──────────────────────────────────────
+
+/// Create an MTLEvent for inter-queue synchronization.
+pub fn create_event(device: &Device) -> *mut std::ffi::c_void {
+    unsafe { ffi::gpu_bridge_create_event(device.raw_handle()) }
+}
+
+/// Encode a signal on a command buffer: sets event value after all prior work completes.
+pub fn encode_signal_event(cb: *mut std::ffi::c_void, event: *mut std::ffi::c_void, value: u64) {
+    unsafe { ffi::gpu_bridge_encode_signal_event(cb, event, value) }
+}
+
+/// Encode a wait on a command buffer: blocks until event reaches the given value.
+pub fn encode_wait_event(cb: *mut std::ffi::c_void, event: *mut std::ffi::c_void, value: u64) {
+    unsafe { ffi::gpu_bridge_encode_wait_event(cb, event, value) }
+}
+
+/// Destroy an MTLEvent (release the retained reference).
+pub fn destroy_event(event: *mut std::ffi::c_void) {
+    unsafe { ffi::gpu_bridge_destroy_event(event) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/ffi.rs
+++ b/crates/core/src/ffi.rs
@@ -707,6 +707,20 @@ extern "C" {
         diagonal: i32,
     ) -> *mut std::ffi::c_void;
 
+    // ── Concurrent queue pool ──────────────────────────────────────────
+    pub fn gpu_bridge_get_queue(device: *const GPUDeviceHandle, index: u32) -> *mut std::ffi::c_void;
+
+    // ── Batch context system ─────────────────────────────────────────
+    pub fn gpu_bridge_set_batch_context(context_id: u32, queue: *mut std::ffi::c_void) -> *mut std::ffi::c_void;
+    pub fn gpu_bridge_commit_batch_context(context_id: u32) -> *mut std::ffi::c_void;
+    pub fn gpu_bridge_set_active_context(context_id: u32);
+
+    // ── MTLEvent synchronization ─────────────────────────────────────
+    pub fn gpu_bridge_create_event(device: *const GPUDeviceHandle) -> *mut std::ffi::c_void;
+    pub fn gpu_bridge_encode_signal_event(cb: *mut std::ffi::c_void, event: *mut std::ffi::c_void, value: u64);
+    pub fn gpu_bridge_encode_wait_event(cb: *mut std::ffi::c_void, event: *mut std::ffi::c_void, value: u64);
+    pub fn gpu_bridge_destroy_event(event: *mut std::ffi::c_void);
+
     // Generic 3D dispatch for CNN ops
     pub fn gpu_bridge_compute_3d(
         compute: *mut GPUComputeHandle,

--- a/crates/core/src/graph.rs
+++ b/crates/core/src/graph.rs
@@ -445,6 +445,35 @@ impl Graph {
         self.nodes.len()
     }
 
+    /// Partition a topo-sorted subgraph into parallel depth levels.
+    /// Nodes at the same level have no data dependencies on each other.
+    pub fn parallel_levels(&self, target_id: u64) -> crate::error::Result<Vec<Vec<u64>>> {
+        let order = self.topo_sort(target_id)?;
+        if order.is_empty() {
+            return Ok(vec![]);
+        }
+        let mut depth: std::collections::HashMap<u64, usize> = std::collections::HashMap::new();
+
+        for &id in &order {
+            let node = self.get_node(id).ok_or_else(|| {
+                crate::error::GpuError::GraphError(format!("Node {} not in graph", id))
+            })?;
+            let d = node.inputs.iter()
+                .filter_map(|&inp| depth.get(&inp))
+                .max()
+                .map(|m| m + 1)
+                .unwrap_or(0);
+            depth.insert(id, d);
+        }
+
+        let max_depth = depth.values().copied().max().unwrap_or(0);
+        let mut levels = vec![Vec::new(); max_depth + 1];
+        for &id in &order {
+            levels[depth[&id]].push(id);
+        }
+        Ok(levels)
+    }
+
     /// Remove all nodes belonging to a container. Returns their IDs.
     pub fn remove_nodes_for_container(&mut self, container_id: ContainerId) -> Vec<u64> {
         let ids: Vec<u64> = self.nodes.iter()
@@ -570,6 +599,53 @@ mod tests {
 
         let order = g.topo_sort(4).unwrap();
         assert_eq!(order, vec![4]); // only node 4, not node 3
+    }
+
+    #[test]
+    fn test_parallel_levels_diamond() {
+        // A -> B, A -> C, B -> D, C -> D
+        let mut g = Graph::new();
+        let a = OpNode { id: 1, inputs: vec![], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Relu, container_id: ContainerId::DEFAULT };
+        let b = OpNode { id: 2, inputs: vec![1], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Relu, container_id: ContainerId::DEFAULT };
+        let c = OpNode { id: 3, inputs: vec![1], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Relu, container_id: ContainerId::DEFAULT };
+        let d = OpNode { id: 4, inputs: vec![2, 3], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Add, container_id: ContainerId::DEFAULT };
+        g.add_node(a); g.add_node(b); g.add_node(c); g.add_node(d);
+
+        let levels = g.parallel_levels(4).unwrap();
+        assert_eq!(levels.len(), 3); // level 0: [A], level 1: [B, C], level 2: [D]
+        assert_eq!(levels[0].len(), 1);
+        assert_eq!(levels[1].len(), 2);
+        assert_eq!(levels[2].len(), 1);
+        assert!(levels[1].contains(&2) && levels[1].contains(&3));
+    }
+
+    #[test]
+    fn test_parallel_levels_linear() {
+        // A -> B -> C (all linear, each level has 1 node)
+        let mut g = Graph::new();
+        g.add_node(OpNode { id: 1, inputs: vec![], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Relu, container_id: ContainerId::DEFAULT });
+        g.add_node(OpNode { id: 2, inputs: vec![1], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Relu, container_id: ContainerId::DEFAULT });
+        g.add_node(OpNode { id: 3, inputs: vec![2], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Relu, container_id: ContainerId::DEFAULT });
+
+        let levels = g.parallel_levels(3).unwrap();
+        assert_eq!(levels.len(), 3);
+        assert!(levels.iter().all(|l| l.len() == 1)); // all linear
+    }
+
+    #[test]
+    fn test_parallel_levels_wide() {
+        // 4 independent nodes (no deps) -> all at level 0
+        let mut g = Graph::new();
+        for i in 1..=4 {
+            g.add_node(OpNode { id: i, inputs: vec![], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Relu, container_id: ContainerId::DEFAULT });
+        }
+        // Fan-in: node 5 depends on all four
+        g.add_node(OpNode { id: 5, inputs: vec![1, 2, 3, 4], out_shape: Shape::new(vec![2]).unwrap(), out_dtype: DType::Float32, op: OpKind::Add, container_id: ContainerId::DEFAULT });
+
+        let levels = g.parallel_levels(5).unwrap();
+        assert_eq!(levels.len(), 2);
+        assert_eq!(levels[0].len(), 4); // all independent at level 0
+        assert_eq!(levels[1].len(), 1); // fan-in at level 1
     }
 
     #[test]

--- a/crates/core/src/lazy.rs
+++ b/crates/core/src/lazy.rs
@@ -96,9 +96,16 @@ impl LazyRuntime {
     /// Evaluate a tensor: execute all pending ops needed to materialize it.
     /// After evaluation, the tensor is in `self.tensors` and its graph nodes are removed.
     ///
-    /// Uses single command buffer encoding: all ops are encoded into one
-    /// MTLCommandBuffer via begin_batch/end_batch, then we wait once at the end.
-    /// Falls back to per-op command buffers (Phase 2a) if begin_batch fails.
+    /// Dispatches independent ops across multiple Metal command queues (up to 4) using
+    /// `parallel_levels()` to identify ops with no data dependencies between them.
+    /// Each level's command buffers are committed and waited on before proceeding to
+    /// the next level, providing correct per-level synchronization without MTLEvent.
+    /// Falls back to the single command buffer path for linear graphs (zero overhead).
+    ///
+    /// TODO: Phase II could use MTLSharedEvent (which supports multiple signalers via
+    /// monotonically increasing values from different encoders) instead of commit-and-wait.
+    /// Plain MTLEvent is unsuitable because ANY encoder signaling value N marks it done,
+    /// even if other encoders at the same level haven't finished yet.
     pub fn eval(&mut self, device: &Device, id: u64) -> Result<()> {
         if self.is_materialized(id) {
             return Ok(()); // already done
@@ -106,14 +113,104 @@ impl LazyRuntime {
 
         let container_id = self.resolve_container(id);
 
-        let mut order = self.graph.topo_sort(id)?;
+        // Run fusion BEFORE computing parallel levels (fusion mutates graph topology)
+        let order = self.graph.topo_sort(id)?;
         if order.is_empty() {
             return Err(GpuError::GraphError(format!("Tensor {} not found", id)));
         }
+        let _fused_order = crate::fusion::optimize(&mut self.graph, &order);
 
-        // Run fusion optimization pass
-        order = crate::fusion::optimize(&mut self.graph, &order);
+        let levels = self.graph.parallel_levels(id)?;
 
+        // Fast path: linear graph -> existing single-CB path
+        if levels.iter().all(|l| l.len() == 1) {
+            return self.eval_single_cb(device, container_id, levels);
+        }
+
+        let num_queues = std::cmp::min(
+            levels.iter().map(|l| l.len()).max().unwrap_or(1),
+            4,
+        );
+        let queues: Vec<_> = (0..num_queues)
+            .map(|i| crate::compute::get_queue(device, i as u32))
+            .collect();
+
+        let loop_result: Result<()> = (|| {
+            for (_level_idx, level) in levels.iter().enumerate() {
+                // Create ONE command buffer per QUEUE (not per node).
+                // Multiple nodes sharing a queue share a CB.
+                let mut queue_cbs: HashMap<usize, *mut std::ffi::c_void> = HashMap::new();
+                for (i, _) in level.iter().enumerate() {
+                    let queue_idx = i % num_queues;
+                    queue_cbs.entry(queue_idx).or_insert_with(|| {
+                        let ctx_id = (queue_idx + 1) as u32;
+                        let cb = crate::compute::set_batch_context(ctx_id, queues[queue_idx]);
+                        cb // caller checks for null below
+                    });
+                }
+
+                // Check for any null command buffers (set_batch_context failure)
+                if queue_cbs.values().any(|cb| cb.is_null()) {
+                    return Err(GpuError::GraphError(
+                        "Failed to create batch context for one or more queues".to_string(),
+                    ));
+                }
+
+                // Encode ops for this level — each node uses its queue's CB
+                for (node_idx, &node_id) in level.iter().enumerate() {
+                    if self.is_materialized(node_id) { continue; }
+                    let node = self.graph.remove_node(node_id)
+                        .ok_or_else(|| GpuError::GraphError(format!("Node {} not found", node_id)))?;
+                    let out_buf = self.pool.acquire(device, node.out_shape.numel() * node.out_dtype.size_bytes())?;
+                    let out = Tensor::from_raw(node.id, node.out_shape.dims().to_vec(), node.out_dtype, out_buf);
+
+                    // Set active context to this node's queue
+                    let queue_idx = node_idx % num_queues;
+                    crate::compute::set_active_context((queue_idx + 1) as u32);
+                    self.execute_node_nb(device, queues[queue_idx], &node, &out)?;
+
+                    self.scheduler.allocate_tensor(container_id, node_id, node.out_shape.numel() * node.out_dtype.size_bytes())?;
+                    self.tensors.insert(node_id, out);
+                }
+
+                // Commit all CBs for this level, then wait for all to complete
+                // before proceeding to the next level (correct synchronization).
+                let mut level_cbs: Vec<*mut std::ffi::c_void> = Vec::new();
+                for (&queue_idx, &_cb) in &queue_cbs {
+                    let ctx_id = (queue_idx + 1) as u32;
+                    let committed = crate::compute::commit_batch_context(ctx_id);
+                    level_cbs.push(committed);
+                }
+                for cb in &level_cbs {
+                    if !cb.is_null() {
+                        crate::compute::wait_command_buffer(*cb);
+                    }
+                }
+            }
+            Ok(())
+        })();
+
+        // Reset active context to default
+        crate::compute::set_active_context(0);
+
+        // On error, clean up any uncommitted batch contexts
+        if loop_result.is_err() {
+            for queue_idx in 0..num_queues {
+                let ctx_id = (queue_idx + 1) as u32;
+                let cb = crate::compute::commit_batch_context(ctx_id);
+                if !cb.is_null() {
+                    crate::compute::wait_command_buffer(cb);
+                }
+            }
+        }
+
+        loop_result
+    }
+
+    /// Single command buffer eval path — used for linear graphs (no parallelism)
+    /// and as fallback when MTLEvent creation fails.
+    fn eval_single_cb(&mut self, device: &Device, container_id: ContainerId, levels: Vec<Vec<u64>>) -> Result<()> {
+        let order: Vec<u64> = levels.into_iter().flat_map(|l| l.into_iter()).collect();
         let queue = crate::compute::get_shared_queue(device);
         let batch_cb = crate::compute::begin_batch(queue);
         let use_batch = !batch_cb.is_null();
@@ -121,23 +218,15 @@ impl LazyRuntime {
 
         let loop_result: Result<()> = (|| {
             for node_id in order {
-                if self.is_materialized(node_id) {
-                    continue;
-                }
-
+                if self.is_materialized(node_id) { continue; }
                 let node = self.graph.remove_node(node_id).ok_or_else(|| {
                     GpuError::GraphError(format!("Node {} not found in graph", node_id))
                 })?;
-
                 let out_size = node.out_shape.numel() * node.out_dtype.size_bytes();
                 let out_buf = self.pool.acquire(device, out_size)?;
                 let out = Tensor::from_raw(node.id, node.out_shape.dims().to_vec(), node.out_dtype, out_buf);
-
                 let cb = self.execute_node_nb(device, queue, &node, &out)?;
-                if !use_batch {
-                    last_cb = Some(cb);
-                }
-
+                if !use_batch { last_cb = Some(cb); }
                 let size = node.out_shape.numel() * node.out_dtype.size_bytes();
                 self.scheduler.allocate_tensor(container_id, node_id, size)?;
                 self.tensors.insert(node_id, out);
@@ -145,7 +234,6 @@ impl LazyRuntime {
             Ok(())
         })();
 
-        // Finalize: commit or abort the batch, then wait
         if use_batch {
             if loop_result.is_ok() {
                 let cb = crate::compute::end_batch();
@@ -158,7 +246,6 @@ impl LazyRuntime {
         } else if let Some(cb) = last_cb {
             crate::compute::wait_command_buffer(cb);
         }
-
         loop_result
     }
 

--- a/python/tests/test_concurrent_queues.py
+++ b/python/tests/test_concurrent_queues.py
@@ -1,0 +1,44 @@
+"""Tests for concurrent Metal queue dispatch (Phase I concurrency)."""
+import applegpu_runtime as gpu
+
+
+def test_diamond_graph():
+    """A -> B, A -> C, B+C -> D. B and C should execute on separate queues."""
+    gpu.init_backend()
+    a = gpu.tensor([1.0, 2.0, 3.0, 4.0], [4])
+    b = a + a          # depends on a
+    c = a * a          # depends on a, independent of b
+    d = b + c          # depends on b and c
+    d.eval()
+    result = d.to_list()
+    expected = [1+1+1*1, 2+2+2*2, 3+3+3*3, 4+4+4*4]
+    assert result == expected, f"Got {result}, expected {expected}"
+
+
+def test_wide_independent_ops():
+    """4 independent operations that can all execute in parallel."""
+    gpu.init_backend()
+    a = gpu.tensor([1.0, 2.0, 3.0, 4.0], [4])
+    b = a + a
+    c = a * a
+    d = a - a
+    e = gpu.relu(a)
+    # Force a join point
+    result = b + c + d + e
+    result.eval()
+    vals = result.to_list()
+    # b=2,4,6,8  c=1,4,9,16  d=0,0,0,0  e=1,2,3,4
+    expected = [2+1+0+1, 4+4+0+2, 6+9+0+3, 8+16+0+4]
+    assert vals == expected, f"Got {vals}, expected {expected}"
+
+
+def test_linear_chain_fast_path():
+    """Linear chain should take the single-CB fast path and produce correct results."""
+    gpu.init_backend()
+    a = gpu.tensor([1.0, 2.0, 3.0, 4.0], [4])
+    b = a + a           # 2, 4, 6, 8
+    c = b + a           # 3, 6, 9, 12
+    c.eval()
+    result = c.to_list()
+    expected = [3.0, 6.0, 9.0, 12.0]
+    assert result == expected, f"Got {result}, expected {expected}"

--- a/swift/Sources/AppleGPUBridge/compute.swift
+++ b/swift/Sources/AppleGPUBridge/compute.swift
@@ -12,6 +12,18 @@ private let sharedQueueLock = NSLock()
 private var activeBatchCommandBuffer: MTLCommandBuffer?
 private let batchLock = NSLock()
 
+// --- Queue pool for concurrent dispatch ---
+private var queuePool: [MTLCommandQueue] = []
+private let queuePoolLock = NSLock()
+private let maxQueueCount: Int = 4
+
+// --- Batch context system ---
+private var batchContexts: [UInt32: MTLCommandBuffer] = [:]
+private let contextLock = NSLock()
+// Phase I: module-level variable, safe because outer Mutex serializes all eval calls.
+// Phase II: MUST move to thread-local storage (Thread.current.threadDictionary or pthread key).
+private var currentContextId: UInt32 = 0
+
 /// Wraps a Metal compute pipeline with command queue.
 final class GPUCompute {
     let device: MTLDevice
@@ -586,6 +598,13 @@ final class GPUCompute {
     func dispatchGatherNB(queue: MTLCommandQueue, bufIn: MTLBuffer, bufIndices: MTLBuffer,
                           bufOut: MTLBuffer, rows: Int, inCols: Int, outCols: Int) -> (AnyObject, Bool)? {
         if rows == 0 || outCols == 0 {
+            let ctxId = currentContextId
+            contextLock.lock()
+            if ctxId > 0, let batchCB = batchContexts[ctxId] {
+                contextLock.unlock()
+                return (batchCB as AnyObject, true)
+            }
+            contextLock.unlock()
             batchLock.lock()
             let result = activeBatchCommandBuffer.map { ($0 as AnyObject, true) }
             batchLock.unlock()
@@ -594,16 +613,25 @@ final class GPUCompute {
 
         let commandBuffer: MTLCommandBuffer
         let isBatch: Bool
-        batchLock.lock()
-        if let batchCB = activeBatchCommandBuffer {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
             commandBuffer = batchCB
             isBatch = true
-            batchLock.unlock()
+            contextLock.unlock()
         } else {
-            batchLock.unlock()
-            guard let cb = queue.makeCommandBuffer() else { return nil }
-            commandBuffer = cb
-            isBatch = false
+            contextLock.unlock()
+            batchLock.lock()
+            if let batchCB = activeBatchCommandBuffer {
+                commandBuffer = batchCB
+                isBatch = true
+                batchLock.unlock()
+            } else {
+                batchLock.unlock()
+                guard let cb = queue.makeCommandBuffer() else { return nil }
+                commandBuffer = cb
+                isBatch = false
+            }
         }
 
         guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1232,6 +1260,13 @@ public func gpuBridgeComputeElementwiseNB(
 
     let count = Int(elementCount)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1240,16 +1275,25 @@ public func gpuBridgeComputeElementwiseNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1299,6 +1343,13 @@ public func gpuBridgeComputeUnaryNB(
 
     let count = Int(elementCount)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1307,16 +1358,25 @@ public func gpuBridgeComputeUnaryNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1386,6 +1446,13 @@ public func gpuBridgeComputeMatmulBatchedNB(
     let bufC = Unmanaged<GPUBuffer>.fromOpaque(bufCPtr).takeUnretainedValue()
 
     if M == 0 || N == 0 || K == 0 || batchSize == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1394,16 +1461,25 @@ public func gpuBridgeComputeMatmulBatchedNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1458,6 +1534,13 @@ public func gpuBridgeComputeSoftmaxCausalNB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if batchSize == 0 || rows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1466,16 +1549,25 @@ public func gpuBridgeComputeSoftmaxCausalNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1525,6 +1617,13 @@ public func gpuBridgeComputeSoftmaxNB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if rows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1533,16 +1632,25 @@ public func gpuBridgeComputeSoftmaxNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1593,6 +1701,13 @@ public func gpuBridgeComputeTransposeNB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if rows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1601,16 +1716,25 @@ public func gpuBridgeComputeTransposeNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1660,6 +1784,13 @@ public func gpuBridgeComputeTransposeBatchedNB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if batchSize == 0 || rows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1668,16 +1799,25 @@ public func gpuBridgeComputeTransposeBatchedNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1728,6 +1868,13 @@ public func gpuBridgeComputeScalarMulNB(
 
     let count = Int(elementCount)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1736,16 +1883,25 @@ public func gpuBridgeComputeScalarMulNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1803,6 +1959,13 @@ public func gpuBridgeComputeFusedNB(
 
     let count = Int(elementCount)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1811,16 +1974,25 @@ public func gpuBridgeComputeFusedNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1878,6 +2050,13 @@ public func gpuBridgeComputeLayerNormNB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if rows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1886,16 +2065,25 @@ public func gpuBridgeComputeLayerNormNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -1952,6 +2140,13 @@ public func gpuBridgeComputeSoftmaxBackwardNB(
     let bufGradIn = Unmanaged<GPUBuffer>.fromOpaque(bufGradInPtr).takeUnretainedValue()
 
     if rows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -1960,16 +2155,25 @@ public func gpuBridgeComputeSoftmaxBackwardNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2028,6 +2232,13 @@ public func gpuBridgeComputeLayerNormBackwardNB(
     let bufGradIn = Unmanaged<GPUBuffer>.fromOpaque(bufGradInPtr).takeUnretainedValue()
 
     if rows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2036,16 +2247,25 @@ public func gpuBridgeComputeLayerNormBackwardNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2093,16 +2313,25 @@ public func gpuBridgeBlitCopyNonBlocking(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let blitEncoder = commandBuffer.makeBlitCommandEncoder() else { return nil }
@@ -2141,6 +2370,13 @@ public func gpuBridgeComputeEmbeddingNB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if seqLen == 0 || embedDim == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2149,16 +2385,25 @@ public func gpuBridgeComputeEmbeddingNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2209,6 +2454,13 @@ public func gpuBridgeComputeSliceDim0NB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if outRows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2217,16 +2469,25 @@ public func gpuBridgeComputeSliceDim0NB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2275,6 +2536,13 @@ public func gpuBridgeComputeSliceDim1NB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if rows == 0 || outCols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2283,16 +2551,25 @@ public func gpuBridgeComputeSliceDim1NB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2344,6 +2621,13 @@ public func gpuBridgeComputeConcatDim0NB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if totalRows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2352,16 +2636,25 @@ public func gpuBridgeComputeConcatDim0NB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2413,6 +2706,13 @@ public func gpuBridgeComputeConcatDim1NB(
 
     let totalCols = Int(colsA) + Int(colsB)
     if rows == 0 || totalCols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2421,16 +2721,25 @@ public func gpuBridgeComputeConcatDim1NB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2481,6 +2790,13 @@ public func gpuBridgeComputeAddBiasNB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if rows == 0 || cols == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2489,16 +2805,25 @@ public func gpuBridgeComputeAddBiasNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2619,6 +2944,13 @@ public func gpuBridgeComputeBinaryNDNB(
 
     let count = Int(numel)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2627,16 +2959,25 @@ public func gpuBridgeComputeBinaryNDNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2749,6 +3090,13 @@ public func gpuBridgeComputeUnaryNDNB(
 
     let count = Int(numel)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2757,16 +3105,25 @@ public func gpuBridgeComputeUnaryNDNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -2883,6 +3240,13 @@ public func gpuBridgeComputePowNDNB(
 
     let count = Int(numel)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -2891,16 +3255,25 @@ public func gpuBridgeComputePowNDNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -3023,6 +3396,13 @@ public func gpuBridgeComputeClampNDNB(
 
     let count = Int(numel)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -3031,16 +3411,25 @@ public func gpuBridgeComputeClampNDNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -3181,6 +3570,13 @@ public func gpuBridgeComputeWhereNDNB(
 
     let count = Int(numel)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -3189,16 +3585,25 @@ public func gpuBridgeComputeWhereNDNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -3331,6 +3736,13 @@ public func gpuBridgeComputeMaskedFillNDNB(
 
     let count = Int(numel)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -3339,16 +3751,25 @@ public func gpuBridgeComputeMaskedFillNDNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -3456,6 +3877,13 @@ public func gpuBridgeComputeTriangularNB(
     let bufOut = Unmanaged<GPUBuffer>.fromOpaque(bufOutPtr).takeUnretainedValue()
 
     if rows == 0 || cols == 0 || batchSize == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -3464,16 +3892,25 @@ public func gpuBridgeComputeTriangularNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -3599,6 +4036,13 @@ public func gpuBridgeComputeFusedNDNB(
     let n = Int(bufferCount)
     let count = Int(numel)
     if count == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -3607,16 +4051,25 @@ public func gpuBridgeComputeFusedNDNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -3766,6 +4219,13 @@ public func gpuBridgeCompute3DNB(
     let n = Int(bufferCount)
     let gx = Int(gridX), gy = Int(gridY), gz = Int(gridZ)
     if gx == 0 || gy == 0 || gz == 0 {
+        let ctxId = currentContextId
+        contextLock.lock()
+        if ctxId > 0, let batchCB = batchContexts[ctxId] {
+            contextLock.unlock()
+            return Unmanaged.passUnretained(batchCB as AnyObject).toOpaque()
+        }
+        contextLock.unlock()
         batchLock.lock()
         let ptr = activeBatchCommandBuffer.map { Unmanaged.passUnretained($0 as AnyObject).toOpaque() }
         batchLock.unlock()
@@ -3774,16 +4234,25 @@ public func gpuBridgeCompute3DNB(
 
     let commandBuffer: MTLCommandBuffer
     let isBatch: Bool
-    batchLock.lock()
-    if let batchCB = activeBatchCommandBuffer {
+    let ctxId = currentContextId
+    contextLock.lock()
+    if ctxId > 0, let batchCB = batchContexts[ctxId] {
         commandBuffer = batchCB
         isBatch = true
-        batchLock.unlock()
+        contextLock.unlock()
     } else {
-        batchLock.unlock()
-        guard let cb = queue.makeCommandBuffer() else { return nil }
-        commandBuffer = cb
-        isBatch = false
+        contextLock.unlock()
+        batchLock.lock()
+        if let batchCB = activeBatchCommandBuffer {
+            commandBuffer = batchCB
+            isBatch = true
+            batchLock.unlock()
+        } else {
+            batchLock.unlock()
+            guard let cb = queue.makeCommandBuffer() else { return nil }
+            commandBuffer = cb
+            isBatch = false
+        }
     }
 
     guard let encoder = commandBuffer.makeComputeCommandEncoder() else { return nil }
@@ -3858,4 +4327,88 @@ public func gpuBridgeAbortBatch() {
     batchLock.lock()
     defer { batchLock.unlock() }
     activeBatchCommandBuffer = nil
+}
+
+// MARK: - Concurrent queue pool
+
+@_cdecl("gpu_bridge_get_queue")
+public func gpuBridgeGetQueue(_ devicePtr: UnsafeRawPointer?, _ index: UInt32) -> UnsafeMutableRawPointer? {
+    guard let devicePtr = devicePtr else { return nil }
+    let gpuDevice = getGPUDevice(from: devicePtr)
+
+    queuePoolLock.lock()
+    defer { queuePoolLock.unlock() }
+
+    let idx = Int(index) % maxQueueCount
+    // Lazily create queues as needed
+    while queuePool.count <= idx {
+        guard let q = gpuDevice.device.makeCommandQueue() else { return nil }
+        queuePool.append(q)
+    }
+    return Unmanaged.passUnretained(queuePool[idx]).toOpaque()
+}
+
+// MARK: - Batch context system
+
+@_cdecl("gpu_bridge_set_active_context")
+public func gpuBridgeSetActiveContext(_ contextId: UInt32) {
+    currentContextId = contextId
+}
+
+@_cdecl("gpu_bridge_set_batch_context")
+public func gpuBridgeSetBatchContext(_ contextId: UInt32, _ queuePtr: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
+    guard let queuePtr = queuePtr else { return nil }
+    let queue = Unmanaged<MTLCommandQueue>.fromOpaque(queuePtr).takeUnretainedValue()
+    guard let cb = queue.makeCommandBuffer() else { return nil }
+
+    contextLock.lock()
+    batchContexts[contextId] = cb
+    contextLock.unlock()
+
+    return Unmanaged.passUnretained(cb).toOpaque()
+}
+
+@_cdecl("gpu_bridge_commit_batch_context")
+public func gpuBridgeCommitBatchContext(_ contextId: UInt32) -> UnsafeMutableRawPointer? {
+    contextLock.lock()
+    guard let cb = batchContexts.removeValue(forKey: contextId) else {
+        contextLock.unlock()
+        return nil
+    }
+    contextLock.unlock()
+
+    cb.commit()
+    return Unmanaged.passRetained(cb as AnyObject).toOpaque()
+}
+
+// MARK: - MTLEvent synchronization
+
+@_cdecl("gpu_bridge_create_event")
+public func gpuBridgeCreateEvent(_ devicePtr: UnsafeRawPointer?) -> UnsafeMutableRawPointer? {
+    guard let devicePtr = devicePtr else { return nil }
+    let gpuDevice = getGPUDevice(from: devicePtr)
+    guard let event = gpuDevice.device.makeEvent() else { return nil }
+    return Unmanaged.passRetained(event as AnyObject).toOpaque()
+}
+
+@_cdecl("gpu_bridge_encode_signal_event")
+public func gpuBridgeEncodeSignalEvent(_ cbPtr: UnsafeMutableRawPointer?, _ eventPtr: UnsafeMutableRawPointer?, _ value: UInt64) {
+    guard let cbPtr = cbPtr, let eventPtr = eventPtr else { return }
+    let cb = Unmanaged<AnyObject>.fromOpaque(cbPtr).takeUnretainedValue() as! MTLCommandBuffer
+    let event = Unmanaged<AnyObject>.fromOpaque(eventPtr).takeUnretainedValue() as! MTLEvent
+    cb.encodeSignalEvent(event, value: value)
+}
+
+@_cdecl("gpu_bridge_encode_wait_event")
+public func gpuBridgeEncodeWaitEvent(_ cbPtr: UnsafeMutableRawPointer?, _ eventPtr: UnsafeMutableRawPointer?, _ value: UInt64) {
+    guard let cbPtr = cbPtr, let eventPtr = eventPtr else { return }
+    let cb = Unmanaged<AnyObject>.fromOpaque(cbPtr).takeUnretainedValue() as! MTLCommandBuffer
+    let event = Unmanaged<AnyObject>.fromOpaque(eventPtr).takeUnretainedValue() as! MTLEvent
+    cb.encodeWaitForEvent(event, value: value)
+}
+
+@_cdecl("gpu_bridge_destroy_event")
+public func gpuBridgeDestroyEvent(_ eventPtr: UnsafeMutableRawPointer?) {
+    guard let eventPtr = eventPtr else { return }
+    Unmanaged<AnyObject>.fromOpaque(eventPtr).release()
 }

--- a/swift/Sources/AppleGPUBridge/include/bridge.h
+++ b/swift/Sources/AppleGPUBridge/include/bridge.h
@@ -719,4 +719,18 @@ void* gpu_bridge_compute_3d_nb(
     uint32_t grid_z
 );
 
+// ── Concurrent queue pool ────────────────────────────────────────────────────
+void* gpu_bridge_get_queue(const void* device, uint32_t index);
+
+// ── Batch context system ─────────────────────────────────────────────────────
+void* gpu_bridge_set_batch_context(uint32_t context_id, void* queue);
+void* gpu_bridge_commit_batch_context(uint32_t context_id);
+void gpu_bridge_set_active_context(uint32_t context_id);
+
+// ── MTLEvent synchronization ─────────────────────────────────────────────────
+void* gpu_bridge_create_event(const void* device);
+void gpu_bridge_encode_signal_event(void* command_buffer, void* event, uint64_t value);
+void gpu_bridge_encode_wait_event(void* command_buffer, void* event, uint64_t value);
+void gpu_bridge_destroy_event(void* event);
+
 #endif

--- a/swift/Tests/AppleGPUBridgeTests/ConcurrencyTests.swift
+++ b/swift/Tests/AppleGPUBridgeTests/ConcurrencyTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import AppleGPUBridge
+
+@Test func queuePoolReturnsNonNilForIndices0Through3() {
+    let devicePtr = gpuBridgeCreateDevice()
+    #expect(devicePtr != nil, "Metal device should be available")
+    guard let devicePtr = devicePtr else { return }
+
+    for i: UInt32 in 0..<4 {
+        let queue = gpuBridgeGetQueue(devicePtr, i)
+        #expect(queue != nil, "Queue at index \(i) should be non-nil")
+    }
+
+    gpuBridgeDestroyDevice(devicePtr)
+}
+
+@Test func createEventReturnsNonNil() {
+    let devicePtr = gpuBridgeCreateDevice()
+    #expect(devicePtr != nil, "Metal device should be available")
+    guard let devicePtr = devicePtr else { return }
+
+    let event = gpuBridgeCreateEvent(devicePtr)
+    #expect(event != nil, "MTLEvent should be creatable")
+
+    gpuBridgeDestroyDevice(devicePtr)
+}


### PR DESCRIPTION
## Summary

- Add `Graph::parallel_levels()` algorithm that partitions topo-sorted subgraphs into depth levels where nodes at the same level are independent
- Swift queue pool (4 `MTLCommandQueue`s), batch context system replacing global `activeBatchCommandBuffer`, MTLEvent FFI infrastructure
- All 30 `_nb` dispatch functions updated to use batch context lookup
- Restructured `eval()`: fusion → parallel_levels → per-level commit-and-wait with one CB per queue per level
- Linear graph fast path with zero overhead for sequential graphs
- Error cleanup for orphaned batch contexts, null checks for CB creation

## Test plan

- [ ] 3 Python tests: diamond graph, wide independent ops, linear chain fast path
- [ ] 2 Swift tests: queue pool creation, MTLEvent creation
- [ ] All 249 Rust tests pass (backward compat via single-CB fast path)
- [ ] All 183+ Python tests pass
- [ ] GPT-2 inference still works

**Spec:** `docs/superpowers/specs/2026-03-16-concurrency-design.md`
**Plan:** `docs/superpowers/plans/2026-03-16-concurrency.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)